### PR TITLE
fix:删除flushForHarmony只用与harmony的方法

### DIFF
--- a/harmony/rn_cookies/src/main/cpp/CookiesTurboModule.cpp
+++ b/harmony/rn_cookies/src/main/cpp/CookiesTurboModule.cpp
@@ -40,10 +40,6 @@ static jsi::Value __hostFunction_RTNCookiesTurboModule_clearAll(jsi::Runtime &rt
     return static_cast<ArkTSTurboModule &>(turboModule).callAsync(rt, "clearAll", args, count);
 }
 
-static jsi::Value __hostFunction_RTNCookiesTurboModule_flushForHarmony(jsi::Runtime &rt, react::TurboModule &turboModule,
-                                                             const jsi::Value *args, size_t count) {
-    return static_cast<ArkTSTurboModule &>(turboModule).callAsync(rt, "flushForHarmony", args, count);
-}
 static jsi::Value __hostFunction_RTNCookiesTurboModule_removeSessionCookies(jsi::Runtime &rt,
                                                                             react::TurboModule &turboModule,
                                                                             const jsi::Value *args, size_t count) {
@@ -57,6 +53,5 @@ RTNCookiesTurboModule::RTNCookiesTurboModule(const ArkTSTurboModule::Context ctx
     methodMap_["set"] = MethodMetadata{3, __hostFunction_RTNCookiesTurboModule_set};
     methodMap_["clearByName"] = MethodMetadata{3, __hostFunction_RTNCookiesTurboModule_clearByName};
     methodMap_["clearAll"] = MethodMetadata{1, __hostFunction_RTNCookiesTurboModule_clearAll};
-    methodMap_["flushForHarmony"] = MethodMetadata{1, __hostFunction_RTNCookiesTurboModule_flushForHarmony};
     methodMap_["removeSessionCookies"] = MethodMetadata{0, __hostFunction_RTNCookiesTurboModule_removeSessionCookies};
 }

--- a/harmony/rn_cookies/src/main/ets/CookiesModule.ts
+++ b/harmony/rn_cookies/src/main/ets/CookiesModule.ts
@@ -150,19 +150,6 @@ export class CookiesModule extends TurboModule {
     }
   }
 
-  flushForHarmony(func: Function): Promise<boolean>{
-    try {
-      return new Promise((resolve) => {
-        func();
-        resolve(true);
-      });
-    } catch(error) {
-      return new Promise((resolve) => {
-        resolve(false);
-      });
-    }
-  }
-
   removeSessionCookies(): Promise<boolean>{
     try {
       web_webview.WebCookieManager.clearSessionCookieSync();

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,8 +34,7 @@ declare module '@react-native-cookies/cookies' {
       name: string,
       useWebKit?: boolean,
     ): Promise<boolean>;
-    // Harmony only
-    flushForHarmony(func: Function): Promise<boolean>;
+    
   }
 
   const CookieManager: CookieManagerStatic;

--- a/index.js
+++ b/index.js
@@ -54,11 +54,7 @@ module.exports = {
       return await CookieManager.removeSessionCookies();
     }
   },
-  flushForHarmony: (func) => {
-    if (Platform.OS === 'harmony') {
-       CookieManager.flushForHarmony(func);
-    }
-  },
+ 
 };
 
 for (var i = 0; i < functions.length; i++) {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- Closes #8 


## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

无

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->