### PR TITLE
fix:修改react-native-cookies的set方法问题

### DIFF
--- a/harmony/rn_cookies/src/main/ets/CookiesModule.ts
+++ b/harmony/rn_cookies/src/main/ets/CookiesModule.ts
@@ -86,14 +86,21 @@ export class CookiesModule extends TurboModule {
       });
     }
   }
+
   isEmpty(value:string) {
     return value == null || value.length === 0;
   }
 
-
   async set(url: string, cookie: Cookie, useWebKit?: boolean): Promise<boolean>{
     try {
+
       let cookieBuilder:string =  cookie.name + '=' + cookie.value
+      Object.keys(cookie).forEach((key)=>{
+        if(key !== "name" && key !== "value" && key !== "domain"){
+          cookieBuilder+= `; ${key}=${cookie[key]}`
+        }
+      })
+
       const topLevelDomain = url.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)[1];
       if (cookie.hasOwnProperty("domain") && !this.isEmpty(cookie.domain)) {
         let domain = cookie.domain;
@@ -103,15 +110,14 @@ export class CookiesModule extends TurboModule {
         if (topLevelDomain !==domain ) {
           throw new Error(`Cookie URL host ${topLevelDomain} and domain ${domain} mismatched. The cookie won't set correctly.`);
         }
-        cookieBuilder+=`;domain = ${domain}`
+        cookieBuilder+=`; domain=${domain}`
       } else {
-        cookieBuilder +=`;domain = ${topLevelDomain}`
+        cookieBuilder +=`; domain=${topLevelDomain}`
       }
-
       if (useWebKit) {
         await web_webview.WebCookieManager.configCookie(url, cookieBuilder);
       } else {
-        web_webview.WebCookieManager.configCookieSync(url, cookieBuilder);
+        web_webview.WebCookieManager.configCookieSync(url, cookieBuilder,false);
       }
       return new Promise((resolve) => {
         resolve(true);


### PR DESCRIPTION


# Summary
fix:修改react-native-cookies的set方法不能设置 path domain  version expires secure httpOnly等问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

